### PR TITLE
Feature/set image latest tag

### DIFF
--- a/.github/workflows/push-sakura-registry.yaml
+++ b/.github/workflows/push-sakura-registry.yaml
@@ -1,6 +1,9 @@
 name: build_image
 
-on: push
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build_and_push:


### PR DESCRIPTION
`latest` タグをイメージに付けられてなかったのを修正しました

```
$ docker pull ictsc2021.sakuracr.jp/ictsc-rikka:latest
latest: Pulling from ictsc-rikka
59bf1c3509f3: Already exists 
aa9592e209f1: Pull complete 
b100f0a4cfbe: Pull complete 
Digest: sha256:4308b73302fa460a3fa1e91ca26534fccb99ebc197880d209c702d2e2d37d340
Status: Downloaded newer image for ictsc2021.sakuracr.jp/ictsc-rikka:latest
ictsc2021.sakuracr.jp/ictsc-rikka:latest
```