### PR TITLE
Fix panic if redis connect failed

### DIFF
--- a/cmd/rikka/main.go
+++ b/cmd/rikka/main.go
@@ -82,6 +82,10 @@ func init() {
 		config.Redis.Password,
 		[]byte(config.Redis.KeyPair),
 	)
+        if err != nil {
+                f.Close()
+                log.Fatalf(errors.Wrapf(err, "Failed to open redis connection.").Error())
+        }
 	store.Options(sessions.Options{
 		MaxAge:   43200,
 		Path:     "/",
@@ -89,10 +93,6 @@ func init() {
 		HttpOnly: true,
 		SameSite: http.SameSiteNoneMode,
 	})
-	if err != nil {
-		f.Close()
-		log.Fatalf(errors.Wrapf(err, "Failed to open redis connection.").Error())
-	}
 	minioClient, err = minio.New(config.Minio.Endpoint, &minio.Options{
 		Creds:  credentials.NewStaticV4(config.Minio.AccessKeyID, config.Minio.SecretAccessKey, ""),
 		Secure: config.Minio.UseSSL,


### PR DESCRIPTION
errorのcheckをする順番がおかしいため、panicが発生する。


正常にErrorメッセージが出ることを確認した。

```shell
2022/02/11 16:01:30 /go/src/ictsc-rikka/cmd/rikka/main.go:69 SLOW SQL >= 200ms
[247.131ms] [rows:-] SELECT count(*) FROM INFORMATION_SCHEMA.table_constraints WHERE constraint_schema = 'rikkadev' AND table_name = 'users' AND constraint_name = 'fk_users_user_group'

2022/02/11 16:01:30 /go/src/ictsc-rikka/cmd/rikka/main.go:69 Error 1826: Duplicate foreign key constraint name 'fk_users_user_group'
[269.890ms] [rows:0] ALTER TABLE `users` ADD CONSTRAINT `fk_users_user_group` FOREIGN KEY (`user_group_id`) REFERENCES `user_groups`(`id`)
2022/02/11 16:01:30 Failed to open redis connection.: dial tcp: lookup redis on 127.0.0.11:53: no such host
exit status 1
make: *** [Makefile:14: run-docker] Error 1
```