### PR TITLE
fix config.yaml.example の cors 部分が間違っていたため構文を修正

### DIFF
--- a/cmd/rikka/config.yaml.example
+++ b/cmd/rikka/config.yaml.example
@@ -1,9 +1,9 @@
 listen:
   address: 0.0.0.0
   port: 8080
-  cors:
+cors:
   origins:
-    - http://localhost:4040
+    - http://localhost:3000s
 notify:
   answer: https://hooks.slack.com/services/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
 # use TLS.


### PR DESCRIPTION
closed #80 

## 主な変更

- fix config.yaml.example の cors 部分が間違っていたため構文を修正