### PR TITLE
fix slack のリンクを削除しとりあえず動く localhost を割り当てた

### DIFF
--- a/cmd/rikka/config.yaml.example
+++ b/cmd/rikka/config.yaml.example
@@ -19,7 +19,7 @@ store:
   sameSiteStrictMode:
   domain:
 notify:
-  answer: https://hooks.slack.com/services/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
+  answer: http://localhost:8080
 ## answerLimit (value * time.Minute)
 contest:
   answerLimit: 20


### PR DESCRIPTION
## 主な変更

- fix: slack のリンクを削除しとりあえず動く localhost を割り当てた

## XX

- 一応無効化されているか確認することって出来ませんか？ @x86taka @onokatio 