### PR TITLE
update ランキングを無制限で閲覧できるように改善

### DIFF
--- a/pkg/controller/ranking.go
+++ b/pkg/controller/ranking.go
@@ -48,21 +48,3 @@ func (c *RankingController) GetRanking() (*Ranking, error) {
 
 	return c.entity2response(ranking), nil
 }
-
-func (c *RankingController) GetTopRanking() (*Ranking, error) {
-	ranking, err := c.rankingService.GetTopRanking()
-	if err != nil {
-		return nil, err
-	}
-
-	return c.entity2response(ranking), nil
-}
-
-func (c *RankingController) GetNearMeRanking(user *entity.User) (*Ranking, error) {
-	ranking, err := c.rankingService.GetNearMeRanking(user)
-	if err != nil {
-		return nil, err
-	}
-
-	return c.entity2response(ranking), nil
-}

--- a/pkg/controller/ranking.go
+++ b/pkg/controller/ranking.go
@@ -48,3 +48,12 @@ func (c *RankingController) GetRanking() (*Ranking, error) {
 
 	return c.entity2response(ranking), nil
 }
+
+func (c *RankingController) GetTopRanking() (*Ranking, error) {
+	ranking, err := c.rankingService.GetTopRanking()
+	if err != nil {
+		return nil, err
+	}
+
+	return c.entity2response(ranking), nil
+}

--- a/pkg/delivery/http/handler/ranking.go
+++ b/pkg/delivery/http/handler/ranking.go
@@ -39,3 +39,13 @@ func (h *RankingHandler) GetRanking(ctx *gin.Context) {
 
 	response.JSON(ctx, http.StatusOK, "", ranking, nil)
 }
+
+func (h *RankingHandler) GetTopRanking(ctx *gin.Context) {
+	ranking, err := h.rankingController.GetTopRanking()
+	if err != nil {
+		ctx.Error(err)
+		return
+	}
+
+	response.JSON(ctx, http.StatusOK, "", ranking, nil)
+}

--- a/pkg/delivery/http/handler/ranking.go
+++ b/pkg/delivery/http/handler/ranking.go
@@ -1,15 +1,12 @@
 package handler
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 	"github.com/ictsc/ictsc-rikka/pkg/controller"
 	"github.com/ictsc/ictsc-rikka/pkg/delivery/http/middleware"
 	"github.com/ictsc/ictsc-rikka/pkg/delivery/http/response"
-	"github.com/ictsc/ictsc-rikka/pkg/entity"
-	"github.com/ictsc/ictsc-rikka/pkg/error"
 	"github.com/ictsc/ictsc-rikka/pkg/repository"
 	"github.com/ictsc/ictsc-rikka/pkg/service"
 )
@@ -26,44 +23,15 @@ func NewRankingHandler(r *gin.RouterGroup, userRepo repository.UserRepository, r
 	route := r.Group("/ranking")
 	{
 		authed := route.Group("")
-		privileged := route.Group("")
 
 		authed.Use(middleware.Auth(userRepo))
-		privileged.Use(middleware.AuthIsFullAccess(userRepo))
 
-		privileged.GET("", handler.GetRanking)
-		authed.GET("/top", handler.GetTopRanking)
-		authed.GET("/near-me", handler.GetNearMeRanking)
+		authed.GET("", handler.GetRanking)
 	}
 }
 
 func (h *RankingHandler) GetRanking(ctx *gin.Context) {
 	ranking, err := h.rankingController.GetRanking()
-	if err != nil {
-		ctx.Error(err)
-		return
-	}
-
-	response.JSON(ctx, http.StatusOK, "", ranking, nil)
-}
-
-func (h *RankingHandler) GetTopRanking(ctx *gin.Context) {
-	ranking, err := h.rankingController.GetTopRanking()
-	if err != nil {
-		ctx.Error(err)
-		return
-	}
-
-	response.JSON(ctx, http.StatusOK, "", ranking, nil)
-}
-
-func (h *RankingHandler) GetNearMeRanking(ctx *gin.Context) {
-	user, ok := ctx.MustGet("user").(*entity.User)
-	if !ok {
-		ctx.Error(error.NewInternalServerError(errors.New("user couldn't get")))
-	}
-
-	ranking, err := h.rankingController.GetNearMeRanking(user)
 	if err != nil {
 		ctx.Error(err)
 		return

--- a/pkg/delivery/http/handler/ranking.go
+++ b/pkg/delivery/http/handler/ranking.go
@@ -26,6 +26,7 @@ func NewRankingHandler(r *gin.RouterGroup, userRepo repository.UserRepository, r
 
 		authed.Use(middleware.Auth(userRepo))
 
+		authed.GET("/top", handler.GetTopRanking)
 		authed.GET("", handler.GetRanking)
 	}
 }

--- a/pkg/service/ranking.go
+++ b/pkg/service/ranking.go
@@ -182,3 +182,20 @@ func (s *RankingService) GetRanking() ([]*Rank, error) {
 
 	return s.table2slice(rankTable), nil
 }
+
+func (s *RankingService) GetTopRanking() ([]*Rank, error) {
+	rankTable, err := s.getRanking(false)
+	if err != nil {
+		return nil, err
+	}
+
+	ranks := s.table2slice(rankTable)
+
+	for i := range ranks {
+		if ranks[i].Rank > 5 {
+			return ranks[:i-1], nil
+		}
+	}
+
+	return ranks, nil
+}

--- a/pkg/service/ranking.go
+++ b/pkg/service/ranking.go
@@ -1,13 +1,11 @@
 package service
 
 import (
-	"errors"
 	"sort"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/ictsc/ictsc-rikka/pkg/entity"
-	e "github.com/ictsc/ictsc-rikka/pkg/error"
 	"github.com/ictsc/ictsc-rikka/pkg/repository"
 )
 
@@ -183,48 +181,4 @@ func (s *RankingService) GetRanking() ([]*Rank, error) {
 	}
 
 	return s.table2slice(rankTable), nil
-}
-
-func (s *RankingService) GetTopRanking() ([]*Rank, error) {
-	rankTable, err := s.getRanking(false)
-	if err != nil {
-		return nil, err
-	}
-
-	ranks := s.table2slice(rankTable)
-
-	for i := range ranks {
-		if ranks[i].Rank > 5 {
-			return ranks[:i-1], nil
-		}
-	}
-
-	return ranks, nil
-}
-
-func (s *RankingService) GetNearMeRanking(user *entity.User) ([]*Rank, error) {
-	rankTable, err := s.getRanking(false)
-	if err != nil {
-		return nil, err
-	}
-
-	ranks := s.table2slice(rankTable)
-
-	cRank, ok := rankTable[user.UserGroupID]
-	if !ok {
-		return nil, e.NewInternalServerError(errors.New("user group not found"))
-	}
-
-	min := cRank.Rank - 1
-	max := cRank.Rank + 1
-
-	pos := 0
-	for _, rank := range ranks {
-		if min <= rank.Rank && rank.Rank <= max {
-			ranks[pos] = rank
-			pos++
-		}
-	}
-
-	return ranks[:pos], nil
 }


### PR DESCRIPTION
## 主な変更

- update ランキングを無制限で閲覧できるように改善
- `/near-me` と `/top` 関連のコードを削除