### PR TITLE
add is_solved, current_point

### DIFF
--- a/pkg/controller/problem.go
+++ b/pkg/controller/problem.go
@@ -113,6 +113,25 @@ func (c *ProblemController) GetAll(metadataOnly bool) (*GetAllProblemsResponse, 
 	}, nil
 }
 
+type GetAllProblemsWithCurrentPointResponse struct {
+	Problems []*entity.ProblemWithCurrentPoint `json:"problems"`
+}
+
+func (c *ProblemController) GetAllProblemsWithCurrentPoint(group *entity.UserGroup, metadataOnly bool) (*GetAllProblemsWithCurrentPointResponse, error) {
+	probs, err := c.problemService.GetAllWithCurrentPoint(group)
+	if err != nil {
+		return nil, err
+	}
+	if metadataOnly {
+		for _, prob := range probs {
+			prob.Body = ""
+		}
+	}
+	return &GetAllProblemsWithCurrentPointResponse{
+		Problems: probs,
+	}, nil
+}
+
 type GetAllProblemsWithAnswerInformationResponse struct {
 	Problems []*entity.ProblemWithAnswerInformation `json:"problems"`
 }

--- a/pkg/delivery/http/handler/problem.go
+++ b/pkg/delivery/http/handler/problem.go
@@ -93,14 +93,14 @@ func (h *ProblemHandler) GetAll(ctx *gin.Context) {
 	metadataOnly := ctx.Query("metadata_only") != ""
 
 	if !group.IsFullAccess {
-		res, err := h.problemController.GetAll(metadataOnly)
+		res, err := h.problemController.GetAllProblemsWithCurrentPoint(group, metadataOnly)
 		if err != nil {
 			ctx.Error(error.NewInternalServerError(err))
 			return
 		}
 		response.JSON(ctx, http.StatusOK, "", res, nil)
 	} else {
-		res, err := h.problemController.GetAllWithAnswerInformation(metadataOnly)
+		res, err := h.problemController.GetAllProblemsWithCurrentPoint(group, metadataOnly)
 		if err != nil {
 			ctx.Error(error.NewInternalServerError(err))
 			return

--- a/pkg/entity/problem.go
+++ b/pkg/entity/problem.go
@@ -42,3 +42,10 @@ type ProblemWithAnswerInformation struct {
 	UncheckedNearOverdue uint `json:"unchecked_near_overdue"`
 	UncheckedOverdue     uint `json:"unchecked_overdue"`
 }
+
+type ProblemWithCurrentPoint struct {
+	Problem
+
+	CurrentPoint uint `json:"current_point"`
+	IsSolved     bool `json:"is_solved"`
+}


### PR DESCRIPTION
#71 

問題一覧ページに以下の表示ができるように、responseに `is_solved` `current_point`の追加を行った。

- 現在獲得しているポイント
- 問題が解き終わっているか

```json
{
	"code": 200,
	"data": {
		"problems": [
			{
				"id": "508a3d8b-a66f-4ff7-bae0-3ea84aa32bb4",
				"created_at": "2023-01-26T09:03:13.415Z",
				"updated_at": "2023-01-26T09:03:13.415Z",
				"code": "abc",
				"author_id": "ef5e0042-9977-4d1f-9d39-9d109cb2bf90",
				"title": "test-problem",
				"body": "test",
				"point": 100,
				"previous_problem_id": null,
				"solved_criterion": 50,
				"current_point": 0,
				"is_solved": false
			}
		]
	}
}
```