### PR TITLE
再展開用のAPIの追加

### DIFF
--- a/cmd/rikka/config.go
+++ b/cmd/rikka/config.go
@@ -7,16 +7,17 @@ import (
 )
 
 type Config struct {
-	Contest ContestConfig   `yaml:"contest"`
-	Listen  ListenConfig    `yaml:"listen"`
-	CORS    CORSConfig      `yaml:"cors"`
-	Store   StoreConfig     `yaml:"store"`
-	Notify  NotifyConfig    `yaml:notify`
-	MariaDB MariaDBConfig   `yaml:"mariadb"`
-	Redis   RedisConfig     `yaml:"redis"`
-	Minio   MinioConfig     `yaml:"minio"`
-	Seed    seed.SeedConfig `yaml:"seed"`
-	Sentry  SentryConfig    `yaml:"sentry"`
+	Contest  ContestConfig   `yaml:"contest"`
+	Listen   ListenConfig    `yaml:"listen"`
+	CORS     CORSConfig      `yaml:"cors"`
+	Store    StoreConfig     `yaml:"store"`
+	Notify   NotifyConfig    `yaml:"notify"`
+	MariaDB  MariaDBConfig   `yaml:"mariadb"`
+	Redis    RedisConfig     `yaml:"redis"`
+	Minio    MinioConfig     `yaml:"minio"`
+	Seed     seed.SeedConfig `yaml:"seed"`
+	Sentry   SentryConfig    `yaml:"sentry"`
+	Recreate RecreateConfig  `yaml:"recreate"`
 }
 
 type ContestConfig struct {
@@ -54,6 +55,10 @@ type RedisConfig struct {
 	Port               int    `yaml:"port"`
 	Password           string `yaml:"password"`
 	KeyPair            string `yaml:"keyPair"`
+}
+
+type RecreateConfig struct {
+	URL string `yaml:"url"`
 }
 
 type MinioConfig struct {

--- a/cmd/rikka/config.yaml.example
+++ b/cmd/rikka/config.yaml.example
@@ -50,3 +50,5 @@ minio:
   accessKeyID:
   secretAccessKey:
   useSSL:
+recreate:
+  url: http://www.example.com

--- a/cmd/rikka/main.go
+++ b/cmd/rikka/main.go
@@ -160,6 +160,7 @@ func main() {
 	problemController := controller.NewProblemController(problemService)
 	answerController := controller.NewAnswerController(answerService)
 	attachmentController := controller.NewAttachmentController(attachmentService)
+	recreateController := controller.NewRecreateController(problemService, config.Recreate.URL)
 
 	errorMiddleware := middleware.NewErrorMiddleware()
 	prometheus := ginprometheus.NewPrometheus("gin")
@@ -211,6 +212,7 @@ func main() {
 		handler.NewProblemHandler(api, userRepo, problemController, answerController)
 		handler.NewAttachmentHandler(api, attachmentController, userRepo)
 		handler.NewRankingHandler(api, userRepo, rankingService)
+		handler.NewRecreateHandler(api, userRepo, problemService, recreateController)
 
 		api.GET("/ping", func(ctx *gin.Context) {
 			ctx.JSON(200, "")

--- a/pkg/controller/recreate.go
+++ b/pkg/controller/recreate.go
@@ -1,0 +1,60 @@
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/ictsc/ictsc-rikka/pkg/entity"
+	"github.com/ictsc/ictsc-rikka/pkg/service"
+)
+
+type RecreateController struct {
+	problemSerice *service.ProblemService
+	host          string
+}
+
+func NewRecreateController(problemService *service.ProblemService, host string) *RecreateController {
+	return &RecreateController{
+		problemSerice: problemService,
+		host:          host,
+	}
+}
+
+func (c *RecreateController) GetStatus(group *entity.UserGroup, probcode string) ([]byte, error) {
+	_, err := c.problemSerice.FindByCode(probcode)
+	if err != nil {
+		return nil, err
+	}
+	url := fmt.Sprintf("%s/%s/%s", c.host, group.TeamID, probcode)
+	resp, err := http.Get(url)
+
+	if err != nil {
+		return nil, errors.New("backend Error")
+	}
+	defer resp.Body.Close()
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.New("io Error")
+	}
+	return b, nil
+}
+
+func (c *RecreateController) CreateRequest(group *entity.UserGroup, probcode string) ([]byte, error) {
+	url := fmt.Sprintf("%s/%s/%s", c.host, group.TeamID, probcode)
+	resp, err := http.Post(url, "", nil)
+
+	if err != nil {
+		return nil, errors.New("backend Error")
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusConflict {
+		return nil, errors.New("Conflict")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New("backend Error")
+	}
+	return c.GetStatus(group, probcode)
+}

--- a/pkg/delivery/http/handler/recreate.go
+++ b/pkg/delivery/http/handler/recreate.go
@@ -1,0 +1,59 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/ictsc/ictsc-rikka/pkg/controller"
+	"github.com/ictsc/ictsc-rikka/pkg/delivery/http/middleware"
+	"github.com/ictsc/ictsc-rikka/pkg/delivery/http/response"
+	"github.com/ictsc/ictsc-rikka/pkg/entity"
+	"github.com/ictsc/ictsc-rikka/pkg/repository"
+	"github.com/ictsc/ictsc-rikka/pkg/service"
+)
+
+type RecreateHandler struct {
+	UserRepository     *repository.UserRepository
+	ProblemService     *service.ProblemService
+	RecreateController *controller.RecreateController
+}
+
+func NewRecreateHandler(r *gin.RouterGroup, userRepo repository.UserRepository, problemService *service.ProblemService, recreateController *controller.RecreateController) {
+	handler := RecreateHandler{
+		RecreateController: recreateController,
+	}
+
+	route := r.Group("/recreate")
+	{
+		authed := route.Group("")
+
+		authed.Use(middleware.Auth(userRepo))
+
+		authed.GET("/:probcode", handler.GetStatus)
+		authed.POST("/:probcode", handler.CreateRecreateRequest)
+	}
+}
+
+func (rh *RecreateHandler) GetStatus(ctx *gin.Context) {
+	group := ctx.MustGet("group").(*entity.UserGroup)
+	probcode := ctx.Param("probcode")
+	b, err := rh.RecreateController.GetStatus(group, probcode)
+	if err != nil {
+		response.JSONRaw(ctx, http.StatusServiceUnavailable, err.Error(), nil, err)
+		return
+	}
+	response.JSONRaw(ctx, http.StatusOK, "", b, nil)
+
+}
+
+func (rh *RecreateHandler) CreateRecreateRequest(ctx *gin.Context) {
+	group := ctx.MustGet("group").(*entity.UserGroup)
+	probcode := ctx.Param("probcode")
+	b, err := rh.RecreateController.CreateRequest(group, probcode)
+	if err != nil {
+		response.JSONRaw(ctx, http.StatusServiceUnavailable, err.Error(), nil, err)
+		return
+	}
+	response.JSONRaw(ctx, http.StatusOK, "", b, nil)
+
+}

--- a/pkg/delivery/http/response/response.go
+++ b/pkg/delivery/http/response/response.go
@@ -1,12 +1,23 @@
 package response
 
-import "github.com/gin-gonic/gin"
+import (
+	"encoding/json"
+
+	"github.com/gin-gonic/gin"
+)
 
 type response struct {
 	Code    int         `json:"code"`
 	Message *string     `json:"message,omitempty"`
 	Data    interface{} `json:"data,omitempty"`
 	Error   interface{} `json:"error,omitempty"`
+}
+
+type responseRaw struct {
+	Code    int             `json:"code"`
+	Message *string         `json:"message,omitempty"`
+	Data    json.RawMessage `json:"data,omitempty"`
+	Error   interface{}     `json:"error,omitempty"`
 }
 
 func JSON(ctx *gin.Context, code int, message string, data, err interface{}) {
@@ -16,6 +27,19 @@ func JSON(ctx *gin.Context, code int, message string, data, err interface{}) {
 		Error: err,
 	}
 
+	if message != "" {
+		res.Message = &message
+	}
+
+	ctx.JSON(code, res)
+}
+
+func JSONRaw(ctx *gin.Context, code int, message string, jsonData []byte, err interface{}) {
+	res := responseRaw{
+		Code:  code,
+		Data:  jsonData,
+		Error: err,
+	}
 	if message != "" {
 		res.Message = &message
 	}

--- a/pkg/entity/user_group.go
+++ b/pkg/entity/user_group.go
@@ -8,4 +8,5 @@ type UserGroup struct {
 	InvitationCodeDigest string   `json:"-" gorm:"not null"`
 	IsFullAccess         bool     `json:"is_full_access" gorm:"not null"`
 	Bastion              *Bastion `json:"bastion,omitempty"`
+	TeamID               string   `json:"-"`
 }


### PR DESCRIPTION
close #104
> GET /api/recreate/:probcode
```
{"code":200,"data":{"available":false,"created_time":"2023-03-01T16:19:44.304688689+09:00","completed_time":null}}
```

> POST /api/recreate/:probcode
```
{"code":200,"data":{"available":false,"created_time":"2023-03-01T15:56:50.152226187+09:00","completed_time":"0001-01-01T00:00:00Z"}}
```
Limitの時
```
{"code":503,"message":"Conflict","error":{}}
```