### PR TITLE
fix: reviewdog がタイムアウトして CI に失敗するのを修正

### DIFF
--- a/.github/workflows/reviewdog-pr.yml
+++ b/.github/workflows/reviewdog-pr.yml
@@ -9,3 +9,5 @@ jobs:
 
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v2
+        with:
+          golangci_lint_flags: --timeout=10m


### PR DESCRIPTION
## 主な変更

* reviewdog がタイムアウトして CI に失敗するのをタイムアウト時間を伸ばして修正